### PR TITLE
Update DynamicAliasAnalysis.cpp

### DIFF
--- a/lib/Analyses/DynamicAliasAnalysis.cpp
+++ b/lib/Analyses/DynamicAliasAnalysis.cpp
@@ -167,6 +167,10 @@ void DynamicAliasAnalysis::removePointedBy(Definition Ptr, Location Loc) {
   auto J = PointedBy.find(Loc);
   assert(J != PointedBy.end());
   J->second.erase(Ptr);
+  /*Do not keep those Location entry which does not map to any Defintion set*/
+  if(0 == J->second.size()) {
+    PointedBy.erase(J);
+  }
 }
 
 void DynamicAliasAnalysis::removePointsTo(Definition Ptr) {

--- a/lib/Analyses/DynamicAliasAnalysis.cpp
+++ b/lib/Analyses/DynamicAliasAnalysis.cpp
@@ -167,8 +167,8 @@ void DynamicAliasAnalysis::removePointedBy(Definition Ptr, Location Loc) {
   auto J = PointedBy.find(Loc);
   assert(J != PointedBy.end());
   J->second.erase(Ptr);
-  /*Do not keep those Location entry which does not map to any Defintion set*/
-  if(0 == J->second.size()) {
+  // Do not keep those Location entry which does not map to any Defintion set.
+  if (0 == J->second.size()) {
     PointedBy.erase(J);
   }
 }


### PR DESCRIPTION
This fix is intended to remove memory thrashing while neongoby offline reads GB sized logs to figure out DidAlias pairs.
The data structure pointedBy is unnecessarily keeping the Location entries even if the Definition Set corresponding to that Location is empty.